### PR TITLE
stack clash protection: Fix a link

### DIFF
--- a/content/posts/2021-01-05-stack-clash-protection.md
+++ b/content/posts/2021-01-05-stack-clash-protection.md
@@ -252,6 +252,8 @@ some impacting both Clang and GCC implementation, the circle is complete!
 
 [GCCStackClashProtection]: https://gcc.gnu.org/legacy-ml/gcc-patches/2017-07/msg00556.html
 
+[CLANGStackClashProtection]: https://reviews.llvm.org/D68720
+
 [RustStackProbe]: https://github.com/rust-lang/rust/pull/77885
 
 [FedoraClangGCC]: https://pagure.io/fesco/issue/2020


### PR DESCRIPTION
Currently, we see
"Support for this flag [landed in Clang in 2020][CLANGStackClashProtection], only for X86, SystemZ and PowerPC"
on 
https://blog.llvm.org/posts/2021-01-05-stack-clash-protection/

