### PR TITLE
Fix a typo (developpers => developers)

### DIFF
--- a/content/posts/2021-01-05-stack-clash-protection.md
+++ b/content/posts/2021-01-05-stack-clash-protection.md
@@ -24,7 +24,7 @@ maintenance][FedoraClangGCC] for packagers.
 
 Support for this flag [landed in Clang in 2020][CLANGStackClashProtection],
 only for X86, SystemZ and PowerPC. Its implementation is a result of a fruitful
-collaboration between LLVM, Firefox and Rust developpers.
+collaboration between LLVM, Firefox and Rust developers.
 
 
 Rust already had a countermeasure implemented in the form of a runtime call to

--- a/content/posts/2021-01-05-stack-clash-protection.md
+++ b/content/posts/2021-01-05-stack-clash-protection.md
@@ -160,7 +160,7 @@ general bug impacting both GCC and LLVM implementation of
 `-fstack-clash-protector`, leading to a new patch set on the LLVM side.
 Essentially, the observed behavior is the following:
 
-Alignment requirement behave similarly to allocation with respect to the stack:
+Alignment requirements behave similarly to allocation with respect to the stack:
 they (may) make it grow. For instance the stack allocation for an `char
 foo[4096] __attribute__((aligned(2048)));` is done through:
 


### PR DESCRIPTION
Thanks to Freddy!