### PR TITLE
Underline links

### DIFF
--- a/themes/hugo-kiera/static/css/styles.css
+++ b/themes/hugo-kiera/static/css/styles.css
@@ -1,2 +1,7 @@
 @import url(./styles-light.css);
 @import url(./styles-dark.css) (prefers-color-scheme: dark);
+
+a {
+  text-decoration: underline;
+}
+


### PR DESCRIPTION
This is obviously subjective, but wouldn't it be better to highlight/underline the links?

Before:

![Screenshot 2021-02-18 at 16 16 11](https://user-images.githubusercontent.com/1175576/108378872-aeeb6f00-7205-11eb-929c-a64d82433ac5.png)

After:

![Screenshot 2021-02-18 at 16 22 29](https://user-images.githubusercontent.com/1175576/108378908-b579e680-7205-11eb-9ad9-180fe237be6a.png)

