### PR TITLE
Make the site compatible with latest Hugo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,8 +4,6 @@ copyright = "llvm.org"
 canonifyurls = true
 theme = "hugo-kiera"
 
-paginate = 10 
-
 summaryLength = 30
 enableEmoji = true
 pygmentsCodeFences = true
@@ -14,22 +12,13 @@ ignoreFiles = ['template.md']
 
 #disqusShortname = "myShortName"
 
+[pagination]
+  pagerSize = 10
+
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
-
-# Note: to disable a social network icon delete or comment out the corresponding line
-[author]
-    name = "LLVM Project"
-    github = "llvm"
-    #gitlab = "username"
-    #linkedin = "username"
-    facebook = "llvmorg"
-    twitter = "llvmorg"
-    #instagram = "username"
-    #stackoverflow = "username"
-    youtube = "c/LLVMPROJ" # or channel/channelname
 
 [params]
     tagline = "LLVM Project News and Details from the Trenches"
@@ -41,6 +30,19 @@ ignoreFiles = ['template.md']
     #utterancesIssueTerm = "pathname"
     homepageLength = 10
     #commentAutoload = true  #This mean reader don't need click, disqus comment autoload
+
+  # Note: to disable a social network icon delete or comment out the corresponding line
+  [params.author]
+    name = "LLVM Project"
+    id="llvmorg"
+    github = "llvm"
+    #gitlab = "username"
+    #linkedin = "username"
+    facebook = "llvmorg"
+    twitter = "llvmorg"
+    #instagram = "username"
+    #stackoverflow = "username"
+    youtube = "c/LLVMPROJ" # or channel/channelname
 
   [[menu.main]]
     identifier = "about"

--- a/themes/hugo-kiera/layouts/_default/rss.xml
+++ b/themes/hugo-kiera/layouts/_default/rss.xml
@@ -8,9 +8,9 @@
    <link>{{ .Permalink }}</link>
    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-   <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-   <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-   <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+   <language>{{.}}</language>{{end}}{{ with .Site.Params.Author.email }}
+   <managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
+   <webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
    {{ with .OutputFormats.Get "RSS" }}
@@ -21,7 +21,7 @@
        <title>{{ .Title }}</title>
        <link>{{ .Permalink }}</link>
        <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+       {{ with .Site.Params.Author.email }}<author>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</author>{{end}}
        <guid>{{ .Permalink }}</guid>
        <description>{{ .Content | replaceRE `[\x00-\x1F\x7F]` "" | html}}</description>
      </item>

--- a/themes/hugo-kiera/layouts/partials/disqus.html
+++ b/themes/hugo-kiera/layouts/partials/disqus.html
@@ -12,7 +12,7 @@
                   return;
 
             var disqus_loaded = false;
-            var disqus_shortname = '{{ .Site.DisqusShortname }}';
+            var disqus_shortname = '{{ .Site.Config.Services.Disqus.Shortname }}';
             var disqus_button = document.getElementById("show-comments");
 
             var disqus_autoload = {{ .Site.Params.commentAutoload }};

--- a/themes/hugo-kiera/layouts/partials/footer.html
+++ b/themes/hugo-kiera/layouts/partials/footer.html
@@ -18,7 +18,7 @@
     </footer>
 </div>
 <script src="{{ "js/scripts.js" | relURL }}"></script>
-{{ if .Site.GoogleAnalytics }}
+{{ if .Site.Config.Services.GoogleAnalytics.ID }}
   {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 {{ partial "user_footer" . }}

--- a/themes/hugo-kiera/layouts/partials/header.html
+++ b/themes/hugo-kiera/layouts/partials/header.html
@@ -23,9 +23,9 @@
           {{ end }}
         {{- end -}}
         {{- range .Site.Data.social.social_icons -}}
-          {{- if isset $.Site.Author .id }}
+          {{- if isset $.Site.Params.Author .id }}
              <li>
-               <a href="{{ printf .url (index $.Site.Author .id) }}" title="{{ .title }}">
+               <a href="{{ printf .url (index $.Site.Params.Author .id) }}" title="{{ .title }}">
                <i class="{{ .icon }} fa-lg"></i>
                </a>
              </li>

--- a/themes/hugo-kiera/layouts/partials/meta.html
+++ b/themes/hugo-kiera/layouts/partials/meta.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="description" content="{{ .Site.Params.description | default "The HTML5 Herald" }}" />
-<meta name="author" content="{{ .Params.Author | default .Site.Author.name }}" />
+<meta name="author" content="{{ .Params.Author | default .Site.Params.Author.name }}" />
 {{- with .OutputFormats.Get "rss" -}}
 	 {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
 {{- end -}}

--- a/themes/hugo-kiera/layouts/partials/single_footer.html
+++ b/themes/hugo-kiera/layouts/partials/single_footer.html
@@ -17,7 +17,7 @@
     {{ if .Site.Params.UtterancesRepo }}
         {{ partial "utterances" . }}
     {{ end }}
-    {{ if .Site.DisqusShortname }}
+    {{ if .Site.Config.Services.Disqus.Shortname }}
         {{ partial "disqus" . }}
     {{ end }}
   {{ end }}


### PR DESCRIPTION
I tested this with Hugo v0.119.0 and latest at time of writing, v0.139.0. It works with both.

(though I don't know which version is being used for the live site, it needs testing with that too)

This fixes a number of issues in our theme, https://github.com/avianto/hugo-kiera.

I'm doing this here instead of upstream because upstream has not been updated in 5 years. I am also not updating the theme to the "latest" because it's likely to break more than it fixes for us.

I have fixed the following problems we had with the latest Hugo.

WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.

Just moved the setting in config.toml.

.Site.DisqusShortName was deprecated and is now removed (https://discourse.gohugo.io/t/error-deprecated-site-disqusshortname-was-deprecated-in-hugo-v0-120-0-and-will-be-removed-in-hugo-0-133-0-use-site-config-services-disqus-shortname-instead/51111)

Use the new name (though we don't enable Disqus anyway).

.Site.GoogleAnalytics was deprecated and is now removed (https://discourse.gohugo.io/t/site-googleanalytics-was-deprecated-in-hugo-v0-120-0-and-will-be-removed-in-hugo-0-134-0/51395)

Use the new name again (another thing we didn't set ayway).

ERROR deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.140.0. Implement taxonomy 'author' or use .Site.Params.Author instead.

Moved the author settings into params.author in config.toml.

I'm not sure every option still works but all the things I could get to on the site do work still.