### PR TITLE
Fix missing authors

### DIFF
--- a/themes/hugo-kiera/layouts/partials/aside.html
+++ b/themes/hugo-kiera/layouts/partials/aside.html
@@ -1,5 +1,6 @@
 <aside>
     <ul>
+        <li>By {{ .Params.Author }}</li>
         <li>
             <time class="post-date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">{{ .Date.Format "Jan 2, 2006" }}</time>
         </li>


### PR DESCRIPTION
[Predictably](https://github.com/llvm/llvm-blog-www/issues/35#issuecomment-1116162115), this went missing after [the recent theme upgrade](https://github.com/llvm/llvm-blog-www/pull/65/files#diff-175c7bae92c8be7c094c925f11320d6de0d730c480154396583382b3619df513L2-L4) 😄

This PR is effectively the same as https://github.com/llvm/llvm-blog-www/pull/36 by @kbeyls

Here is the result:

<img width="760" alt="Screenshot 2024-11-29 at 21 59 50" src="https://github.com/user-attachments/assets/b0f08627-b793-43c3-bc4e-2139611cc09c">
