### PR TITLE
Add GSoC 2026 blog post for "Enabling Float80 and Float128 for unsupported targets in LLVM libc"

### DIFF
--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -50,7 +50,7 @@ bit_cast(const From &from) {
   // ...
 }
 ```
-``` sh
+```sh
 D:\a\llvm-project\llvm-project\libc\src/__support/FPUtil\FPBits.h(863,12): error: no matching function for call to 'bit_cast'
   863 |     return cpp::bit_cast<T>(UP::bits);
       |            ^~~~~~~~~~~~~~~~
@@ -62,7 +62,7 @@ D:\a\llvm-project\llvm-project\libc\test\src\math\smoke\float128_test.cpp(21,12)
 
 The culprit was `BigInt` being zero-initialized in `libc/src/__support/big_int.h`.
 
-```CPP
+```cpp
 template <size_t Bits, bool Signed, typename WordType = uint64_t>
 struct BigInt {
   // ...
@@ -81,7 +81,7 @@ With the member initializer gone, the defaulted constructor is genuinely trivial
 ### 2. The ABI issue with emulated types
 
 A native `float128` uses different registers than the emulated types like `Float128`, which under the hood uses a `UInt128` container.
-While testing LLVM-libc with the CORE-MATH project's test suite, the `bfloat16` (also emulated) functions consistently failed. This was because when compiler support bfloat16 under the name __bf16 is available, it uses different registers than the emulation [BFloat16](https://github.com/llvm/llvm-project/pull/144463) type previously implemented in LLVM libc .
+While testing LLVM-libc with the CORE-MATH project's test suite, the `bfloat16` (also emulated) functions consistently failed. This was because CORE-MATH uses the native `__bf16` type provided by the compiler, which uses different registers than the emulated [BFloat16](https://github.com/llvm/llvm-project/pull/144463) type previously implemented in LLVM libc.
 So we tested our `float128` functions with CORE-MATH and modified them to use the emulation internally for calculations, and the native `float128` when available for parameters/returns, so that in the end the registers used for parameters/returns remain the same and the ABI mismatch is prevented.
 
 The work below on modifying the `float128` functions already uses this idea, making the `float128` functions ABI compatible.

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -78,7 +78,7 @@ The fix was to drop the zero initialization from the declaration and push it int
 
 With the member initializer gone, the defaulted constructor is genuinely trivial, both traits become true, and `bit_cast` accepts the type, which fixed the Windows build.
 
-### 2. The persistent ABI issue with `CORE-MATH`
+### 2. The ABI issue with emulated types
 
 A native `float128` uses different registers than the emulated types like `Float128`, which under the hood uses a `UInt128` container.
 While testing LLVM-libc with the CORE-MATH project's test suite, the `bfloat16` (also emulated) functions consistently failed.
@@ -128,7 +128,7 @@ The work below on modifying the `float128` functions already uses this idea, mak
 
 - We would now be able to use, test and build the `Float128` and `Float80` types even on platforms where they are not natively available.
 - The `float128` functions are now enabled on targets like Windows with MSVC, macOS, and GPU targets.
-- The `Float128` functions can now also be tested with `CORE-MATH` to verify correctness.
+- The `Float128` functions can now also be tested with `CORE-MATH` test-suite to verify correctness.
 
 ## What did I learn?
 

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -7,7 +7,7 @@ title: "GSoC 2026: Enable float80/float128 on Unsupported Targets for LLVM libc"
 
 ## Introduction
 
-Hi, my name is Sukumar Sawant and I had the pleasure of working on the project on introducing `float80` and `float128` (emulated) in LLVM libc this Google Summer of Code 2026 along with my mentors Tue Ly, Nicolas Celik and Krishna Pandey.
+Hello LLVM Community! I am Sukumar Sawant, Computer Science student at Mumbai University (VIT Mumbai), India. I had the pleasure of working on the project on introducing `float80` and `float128` (emulated) in LLVM libc as part of Google Summer of Code 2026 along with my mentors Tue Ly, Nicolas Celik and Krishna Pandey.
 
 ## "Why"?
 

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -127,7 +127,7 @@ The work below on modifying the `float128` functions already uses this idea, mak
 ## Conclusion
 
 - We would now be able to use, test and build the `Float128` and `Float80` types even on platforms where they are not natively available.
-- The `Float80` and `Float128` functions can now use these emulated types for testing on almost every target.
+- The `float128` functions are now enabled on targets like Windows with MSVC, macOS, and GPU targets.
 - The `Float128` functions can now also be tested with `CORE-MATH` to verify correctness.
 
 ## What did I learn?

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -5,10 +5,13 @@ tags: ["GSoC", "libc", "math", "floating-point"]
 title: "GSoC 2026: Float80 and Float128 Emulation in LLVM libc"
 ---
 
+## Introduction
 
-## Introduction and "WHY"?
+Hi, my name is Sukumar Sawant and I had the pleasure of working on the project on introducing `float80` and `float128` (emulated) in LLVM libc this Google Summer of Code 2026 along with my mentors Tue Ly, Nicolas Celik and Krishna Pandey.
 
-`float80` and `float128` are the two extended-precision floating-point formats LLVM libc relies on. `float80` is the 80-bit x87 extended precision format, with 1 sign bit, 15 exponent bits, and a 64-bit significand carrying an explicit integer bit. `float128` is the IEEE 754 `binary128` ("quad precision") format, with 1 sign bit, 15 exponent bits, and 112 stored mantissa bits. Both carry considerably more precision than `double`, which is what makes them useful as the intermediate type in correctly-rounded math routines.
+## "Why"?
+
+`float80` and `float128` are the two extended-precision floating-point formats LLVM libc relies on. `float80` is the 80-bit x87 extended precision format, with 1 sign bit, 15 exponent bits, and a 64-bit significand carrying an explicit integer bit. `float128` is the IEEE 754 `binary128` ("quad precision") format, with 1 sign bit, 15 exponent bits, and 112 stored mantissa bits.
 
 Both formats are already natively supported on several platforms, but not on all of them. For example:
 
@@ -22,10 +25,35 @@ The goal of this project was to lift that restriction by emulating both formats 
 
 The exact goals of this project were to:
 
-1. Add software emulation classes for the `float80` and `float128` formats, backed by LLVM libc's existing `DyadicFloat` arithmetic.
+1. Add software emulation classes for the `float80` and `float128` formats.
 2. Provide the operator overloads and conversions needed for these classes to be used in place of the native types.
-3. Integrate the emulated types into the existing floating-point support infrastructure, so that generic code recognizes and handles them like any other floating-point type.
+3. Integrate the emulated types into the existing floating-point support infrastructure.
 4. Migrate the existing `float128` math functions to work correctly with the emulated type.
+
+## Interesting Challenges
+
+### 1. A `bit_cast` failure that only showed on Windows
+
+`Float128` stores its value in a `UInt128`, which on Windows, without a native 128-bit integer, is `BigInt`. Everything that goes through `cpp::bit_cast` requires it to be trivially constructible and trivially copyable, which was failing in this case.
+
+```cpp
+cpp::is_trivially_constructible<To>::value && cpp::is_trivially_copyable<To>::value
+```
+The culprit was `BigInt` being zero-initialized in many places (in `libc/src/__support/big_int.h`).
+The default member initializer was enough to make the condition fail.
+
+The fix was to drop the zero-init from the declaration and push it into the constructors that actually need it
+([#206277](https://github.com/llvm/llvm-project/pull/206277)).
+
+With the member initializer gone, the defaulted constructor is genuinely trivial, both traits become true, and `bit_cast` accepts the type, which fixed the Windows build.
+
+### 2. The persistent ABI issue with `CORE-MATH`
+
+A native `float128` uses different registers than the emulated types like `Float128`, which under the hood uses a `UInt128` container.
+When comparing against other projects such as CORE-MATH, the `bfloat16` functions consistently failed.
+So we tested our `float128` functions with CORE-MATH and modified them to use the emulation internally for calculations, and the native `float128` when available for input/output, so that in the end the registers used for I/O remain the same and the ABI mismatch is prevented.
+
+The work below on modifying the `float128` functions already uses this idea, making the `float128` functions ABI compatible.
 
 ## Work done
 
@@ -64,25 +92,30 @@ The exact goals of this project were to:
 | `fmodf128`, `remainderf128`                                                                              | [#217578](https://github.com/llvm/llvm-project/pull/217578)     |
 | `sqrtf128`                                                                                               | [#216500](https://github.com/llvm/llvm-project/pull/216500)     |
 | `atan2f128`                                                                                              | [#216508](https://github.com/llvm/llvm-project/pull/216508)     |
-| `bf16addf128`, `bf16subf128`, `bf16mulf128`, `bf16divf128`, `bf16fmaf128`                                |                                                                   |
-| `f16addf128`, `f16subf128`, `f16mulf128`, `f16divf128`                                                   |                                                                   |
-| `f16fmaf128`, `f16sqrtf128`                                                                               |                                                                   |
-| `daddf128`, `dsubf128`, `dmulf128`, `ddivf128`                                                            |                                                                   |
-| `dfmaf128`, `dsqrtf128`                                                                                   |                                                                   |
-| `faddf128`, `fsubf128`, `fmulf128`, `fdivf128`                                                            |                                                                   |
-| `ffmaf128`, `fsqrtf128`                                                                                   |                                                                   |
-| `totalorderf128`, `totalordermagf128`                                                                     |                                                                   |
-| `canonicalizef128`                                                                                         |                                                                   |
-| `frexpf128`, `logbf128`, `ilogbf128`, `llogbf128`                                                          |                                                                   |
-| `ldexpf128`, `scalbnf128`, `scalblnf128`                                                                   |                                                                   |
-| `modff128`                                                                                                 |                                                                   |
-| `nanf128`, `getpayloadf128`, `setpayloadf128`, `setpayloadsigf128`                                         |                                                                   |
-| `remquof128`                                                                                               |                                                                   |
+
+## Conclusion
+
+- We would now be able to use, test and build the `Float128` and `Float80` types even on platforms where they are not natively available.
+- The `Float80` and `Float128` functions can now use these emulated types for testing on almost every target.
+- The `Float128` functions can now also be tested with `CORE-MATH` to verify correctness.
+
+## What did I learn?
+
+One of the most important things I learned was more about floating-point formats, which I'd never have had a chance to go through or play with otherwise. My mentors did let me try new things and learn from them, which helped me discover missing areas or fix any patches I encountered during the project. The fun part is that I also made my first stacked PR during this period. I was also able to get a firmer understanding of emulated types, better C++ programming practices, and the LLVM libc codebase. I came out of this summer knowing a lot more about floating-point formats and C++ than I did before.
 
 ## Future Work
 
+- Complete modification of the remaining `float128` functions.
 - Add explicit `float80` entrypoints.
 - Compare performance of the emulated `float80`/`float128` types against native implementations, where native support is available.
+
+## References
+
+- The previous work on `BFloat16` was quite helpful in designing the current `Float128` and `Float80`: [`bfloat16.h`](https://github.com/llvm/llvm-project/blob/c689c165ba2723285258975a14cd562d41d059ab/libc/src/__support/FPUtil/bfloat16.h#L27-L28)
+- [CORE-MATH](https://gitlab.inria.fr/core-math/core-math/-/blob/4acb80ff2b6fc614023a1ada2110bf7625d3cf8c/src/binaryb16/support/check_exhaustive.c#L42-L43), used to confirm the ABI issue
+- [C23 draft standard (N3220)](https://www.open-std.org/JTC1/SC22/wg14/www/docs/n3220.pdf), used for conversions and handling undefined behavior
+- *Handbook of Floating-Point Arithmetic*, by Jean-Michel Muller et al.
+
 ## Acknowledgements
 
 I’m grateful to Google Summer of Code and the LLVM organization for giving me this opportunity. I would like to sincerely thank my mentors, Tue Ly, Nicolas Celik, and Krishna Pandey, for their guidance, support, and valuable feedback throughout this project and making this a great learning experience.

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -128,7 +128,6 @@ The work below on modifying the `float128` functions already uses this idea, mak
 
 - We would now be able to use, test and build the `Float128` and `Float80` types even on platforms where they are not natively available.
 - The `float128` functions are now enabled on targets like Windows with MSVC, macOS, and GPU targets.
-- We wil soon also be able to test `bfloat16` functions with core-math test suite.
 
 ## What did I learn?
 

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -1,0 +1,90 @@
+---
+author: "Sukumar Sawant"
+date: "2026-08-22"
+tags: ["GSoC", "libc", "math", "floating-point"]
+title: "GSoC 2026: Float80 and Float128 Emulation in LLVM libc"
+---
+
+
+## Introduction and "WHY"?
+
+`float80` and `float128` are the two extended-precision floating-point formats LLVM libc relies on. `float80` is the 80-bit x87 extended precision format, with 1 sign bit, 15 exponent bits, and a 64-bit significand carrying an explicit integer bit. `float128` is the IEEE 754 `binary128` ("quad precision") format, with 1 sign bit, 15 exponent bits, and 112 stored mantissa bits. Both carry considerably more precision than `double`, which is what makes them useful as the intermediate type in correctly-rounded math routines.
+
+Both formats are already natively supported on several platforms, but not on all of them. For example:
+
+* MSVC on Windows treats `long double` as a 64-bit `double` and has no native `__float128` type.
+* AArch64 targets typically use a 128-bit `long double`, but lack the 80-bit extended precision format entirely.
+* Clang on certain non-x86 targets may not enable `__float128` by default.
+
+This matters because LLVM libc needs to build and test its high-precision math routines consistently across every target it supports, not just the ones where these types happen to exist natively. Where the compiler provides no native type, the templated implementations cannot be compiled at all.
+
+The goal of this project was to lift that restriction by emulating both formats in software, so that the same templated implementations build and run everywhere, producing identical results whether the underlying type is native or emulated.
+
+The exact goals of this project were to:
+
+1. Add software emulation classes for the `float80` and `float128` formats, backed by LLVM libc's existing `DyadicFloat` arithmetic.
+2. Provide the operator overloads and conversions needed for these classes to be used in place of the native types.
+3. Integrate the emulated types into the existing floating-point support infrastructure, so that generic code recognizes and handles them like any other floating-point type.
+4. Migrate the existing `float128` math functions to work correctly with the emulated type.
+
+## Work done
+
+- `Float128` emulation type was added to LLVM libc [#200565](https://github.com/llvm/llvm-project/pull/200565).
+- `DyadicFloat<128>` was renamed to `DFloat128` [#200907](https://github.com/llvm/llvm-project/pull/200907).
+- `BigInt` was made trivially constructible, needed for the emulated types [#206277](https://github.com/llvm/llvm-project/pull/206277).
+- `Float80` emulation type was added to LLVM libc [#214447](https://github.com/llvm/llvm-project/pull/214447), along with its operator overloads [#214493](https://github.com/llvm/llvm-project/pull/214493).
+- A float128-to-integer conversion UB bug was fixed [#211593](https://github.com/llvm/llvm-project/pull/211593).
+- Conversion tests between emulated and native `f128` were added [#213422](https://github.com/llvm/llvm-project/pull/213422).
+- `add_sub` was fixed for emulated types [#217344](https://github.com/llvm/llvm-project/pull/217344).
+- A `NEED_MPFR_F128` argument was added to `add_fp_unittest` [#215657](https://github.com/llvm/llvm-project/pull/215657).
+- `LIBC_TYPES_HAS_FLOAT128` was replaced with `LIBC_TYPES_HAS_NATIVE_FLOAT128` for clarity (NFC) [#215605](https://github.com/llvm/llvm-project/pull/215605).
+- Existing `float128` math functions were migrated to use the emulated type, one function (or function family) at a time, tracked under [#216576](https://github.com/llvm/llvm-project/issues/216576) (see table below).
+
+
+| Function / Family                                                                                     | PR                                                             |
+|--------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| `ceilf128`                                                                                              | [#207735](https://github.com/llvm/llvm-project/pull/207735)     |
+| `floorf128`                                                                                             | [#216552](https://github.com/llvm/llvm-project/pull/216552)     |
+| `truncf128`                                                                                             | [#216560](https://github.com/llvm/llvm-project/pull/216560)     |
+| `roundf128`                                                                                             | [#216563](https://github.com/llvm/llvm-project/pull/216563)     |
+| `roundevenf128`                                                                                          | [#216568](https://github.com/llvm/llvm-project/pull/216568)     |
+| `nearbyintf128`                                                                                          | [#217025](https://github.com/llvm/llvm-project/pull/217025)     |
+| `lrintf128`, `llrintf128`, `rintf128`                                                                   | [#217070](https://github.com/llvm/llvm-project/pull/217070)     |
+| `lroundf128`, `llroundf128`                                                                             | [#216829](https://github.com/llvm/llvm-project/pull/216829)     |
+| `fromfpf128`, `fromfpxf128`, `ufromfpf128`, `ufromfpxf128`                                              | [#216578](https://github.com/llvm/llvm-project/pull/216578)     |
+| `fabsf128`, `copysignf128`                                                                              | [#217389](https://github.com/llvm/llvm-project/pull/217389)     |
+| `fmaxf128`, `fminf128`                                                                                   | [#216575](https://github.com/llvm/llvm-project/pull/216575)     |
+| `fmaximumf128`, `fminimumf128`                                                                           | [#217390](https://github.com/llvm/llvm-project/pull/217390)     |
+| `fmaximum_numf128`, `fminimum_numf128`                                                                   | [#217409](https://github.com/llvm/llvm-project/pull/217409)     |
+| `fmaximum_magf128`, `fminimum_magf128`                                                                   | [#217539](https://github.com/llvm/llvm-project/pull/217539)     |
+| `fmaximum_mag_numf128`, `fminimum_mag_numf128`                                                           | [#217549](https://github.com/llvm/llvm-project/pull/217549)     |
+| `fdimf128`                                                                                               | [#217567](https://github.com/llvm/llvm-project/pull/217567)     |
+| `iscanonicalf128`, `isnanf128`, `issignalingf128`                                                       | [#217134](https://github.com/llvm/llvm-project/pull/217134)     |
+| `nextafterf128`, `nextupf128`, `nextdownf128`                                                           | [#217575](https://github.com/llvm/llvm-project/pull/217575)     |
+| `fmodf128`, `remainderf128`                                                                              | [#217578](https://github.com/llvm/llvm-project/pull/217578)     |
+| `sqrtf128`                                                                                               | [#216500](https://github.com/llvm/llvm-project/pull/216500)     |
+| `atan2f128`                                                                                              | [#216508](https://github.com/llvm/llvm-project/pull/216508)     |
+| `bf16addf128`, `bf16subf128`, `bf16mulf128`, `bf16divf128`, `bf16fmaf128`                                |                                                                   |
+| `f16addf128`, `f16subf128`, `f16mulf128`, `f16divf128`                                                   |                                                                   |
+| `f16fmaf128`, `f16sqrtf128`                                                                               |                                                                   |
+| `daddf128`, `dsubf128`, `dmulf128`, `ddivf128`                                                            |                                                                   |
+| `dfmaf128`, `dsqrtf128`                                                                                   |                                                                   |
+| `faddf128`, `fsubf128`, `fmulf128`, `fdivf128`                                                            |                                                                   |
+| `ffmaf128`, `fsqrtf128`                                                                                   |                                                                   |
+| `totalorderf128`, `totalordermagf128`                                                                     |                                                                   |
+| `canonicalizef128`                                                                                         |                                                                   |
+| `frexpf128`, `logbf128`, `ilogbf128`, `llogbf128`                                                          |                                                                   |
+| `ldexpf128`, `scalbnf128`, `scalblnf128`                                                                   |                                                                   |
+| `modff128`                                                                                                 |                                                                   |
+| `nanf128`, `getpayloadf128`, `setpayloadf128`, `setpayloadsigf128`                                         |                                                                   |
+| `remquof128`                                                                                               |                                                                   |
+
+## Future Work
+
+- Add explicit `float80` entrypoints.
+- Compare performance of the emulated `float80`/`float128` types against native implementations, where native support is available.
+## Acknowledgements
+
+I’m grateful to Google Summer of Code and the LLVM organization for giving me this opportunity. I would like to sincerely thank my mentors, Tue Ly, Nicolas Celik, and Krishna Pandey, for their guidance, support, and valuable feedback throughout this project and making this a great learning experience.
+
+I look forward to continuing my contributions to LLVM and the open-source community.

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -62,7 +62,7 @@ D:\a\llvm-project\llvm-project\libc\test\src\math\smoke\float128_test.cpp(21,12)
 
 The culprit was `BigInt` being zero-initialized in `libc/src/__support/big_int.h`.
 
-```
+```CPP
 template <size_t Bits, bool Signed, typename WordType = uint64_t>
 struct BigInt {
   // ...
@@ -81,8 +81,8 @@ With the member initializer gone, the defaulted constructor is genuinely trivial
 ### 2. The ABI issue with emulated types
 
 A native `float128` uses different registers than the emulated types like `Float128`, which under the hood uses a `UInt128` container.
-While testing LLVM-libc with the CORE-MATH project's test suite, the `bfloat16` (also emulated) functions consistently failed.
-So we tested our `float128` functions with CORE-MATH and modified them to use the emulation internally for calculations, and the native `float128` when available for input/output, so that in the end the registers used for parameters/returns remain the same and the ABI mismatch is prevented.
+While testing LLVM-libc with the CORE-MATH project's test suite, the `bfloat16` (also emulated) functions consistently failed. This was because when compiler support bfloat16 under the name __bf16 is available, it uses different registers than the emulation [BFloat16](https://github.com/llvm/llvm-project/pull/144463) type previously implemented in LLVM libc .
+So we tested our `float128` functions with CORE-MATH and modified them to use the emulation internally for calculations, and the native `float128` when available for parameters/returns, so that in the end the registers used for parameters/returns remain the same and the ABI mismatch is prevented.
 
 The work below on modifying the `float128` functions already uses this idea, making the `float128` functions ABI compatible.
 
@@ -128,7 +128,7 @@ The work below on modifying the `float128` functions already uses this idea, mak
 
 - We would now be able to use, test and build the `Float128` and `Float80` types even on platforms where they are not natively available.
 - The `float128` functions are now enabled on targets like Windows with MSVC, macOS, and GPU targets.
-- The `Float128` functions can now also be tested with `CORE-MATH` test-suite to verify correctness.
+- We wil soon also be able to test `bfloat16` functions with core-math test suite.
 
 ## What did I learn?
 

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -2,7 +2,7 @@
 author: "Sukumar Sawant"
 date: "2026-08-22"
 tags: ["GSoC", "libc", "math", "floating-point"]
-title: "GSoC 2026: Float80 and Float128 Emulation in LLVM libc"
+title: "GSoC 2026: Enable float80/float128 on Unsupported Targets for LLVM libc"
 ---
 
 ## Introduction
@@ -11,7 +11,7 @@ Hi, my name is Sukumar Sawant and I had the pleasure of working on the project o
 
 ## "Why"?
 
-`float80` and `float128` are the two extended-precision floating-point formats LLVM libc relies on. `float80` is the 80-bit x87 extended precision format, with 1 sign bit, 15 exponent bits, and a 64-bit significand carrying an explicit integer bit. `float128` is the IEEE 754 `binary128` ("quad precision") format, with 1 sign bit, 15 exponent bits, and 112 stored mantissa bits.
+`float80` and `float128` are the two extended-precision floating-point formats LLVM libc supports. `float80` is the 80-bit x87 extended precision format, with 1 sign bit, 15 exponent bits, and a 64-bit significand carrying an explicit integer bit. `float128` is the IEEE 754 `binary128` ("quad precision") format, with 1 sign bit, 15 exponent bits, and 112 stored mantissa bits.
 
 Both formats are already natively supported on several platforms, but not on all of them. For example:
 
@@ -32,17 +32,48 @@ The exact goals of this project were to:
 
 ## Interesting Challenges
 
-### 1. A `bit_cast` failure that only showed on Windows
+### 1. A `bit_cast` compile error that only showed on Windows
 
-`Float128` stores its value in a `UInt128`, which on Windows, without a native 128-bit integer, is `BigInt`. Everything that goes through `cpp::bit_cast` requires it to be trivially constructible and trivially copyable, which was failing in this case.
+`Float128` stores its value in a `UInt128`, which on Windows, without a native 128-bit integer type, is `BigInt`. LLVM-libc's `cpp::bit_cast` requires the target type to be trivially constructible and trivially copyable, which was causing the compiler error in this case.
 
 ```cpp
-cpp::is_trivially_constructible<To>::value && cpp::is_trivially_copyable<To>::value
+// This implementation of bit_cast requires trivially-constructible To, to avoid
+// UB in the implementation.
+template <typename To, typename From>
+LIBC_INLINE static constexpr cpp::enable_if_t<
+    (sizeof(To) == sizeof(From)) &&
+        cpp::is_trivially_constructible<To>::value &&
+        cpp::is_trivially_copyable<To>::value &&
+        cpp::is_trivially_copyable<From>::value,
+    To>
+bit_cast(const From &from) {
+  // ...
+}
 ```
-The culprit was `BigInt` being zero-initialized in many places (in `libc/src/__support/big_int.h`).
+``` sh
+D:\a\llvm-project\llvm-project\libc\src/__support/FPUtil\FPBits.h(863,12): error: no matching function for call to 'bit_cast'
+  863 |     return cpp::bit_cast<T>(UP::bits);
+      |            ^~~~~~~~~~~~~~~~
+...
+D:\a\llvm-project\llvm-project\libc\test\src\math\smoke\float128_test.cpp(21,12): note: in instantiation of function template specialization '__llvm_libc_23_0_0_git::fputil::Float128::Float128<double>' requested here
+   21 |   Float128 a(1.0), b(1.0), c(2.0);
+      |            ^
+```
+
+The culprit was `BigInt` being zero-initialized in `libc/src/__support/big_int.h`.
+
+```
+template <size_t Bits, bool Signed, typename WordType = uint64_t>
+struct BigInt {
+  // ...
+  cpp::array<WordType, WORD_COUNT> val{}; // zero initialized.
+  // ...
+};
+```
+
 The default member initializer was enough to make the condition fail.
 
-The fix was to drop the zero-init from the declaration and push it into the constructors that actually need it
+The fix was to drop the zero initialization from the declaration and push it into the constructors that actually need it
 ([#206277](https://github.com/llvm/llvm-project/pull/206277)).
 
 With the member initializer gone, the defaulted constructor is genuinely trivial, both traits become true, and `bit_cast` accepts the type, which fixed the Windows build.
@@ -50,8 +81,8 @@ With the member initializer gone, the defaulted constructor is genuinely trivial
 ### 2. The persistent ABI issue with `CORE-MATH`
 
 A native `float128` uses different registers than the emulated types like `Float128`, which under the hood uses a `UInt128` container.
-When comparing against other projects such as CORE-MATH, the `bfloat16` functions consistently failed.
-So we tested our `float128` functions with CORE-MATH and modified them to use the emulation internally for calculations, and the native `float128` when available for input/output, so that in the end the registers used for I/O remain the same and the ABI mismatch is prevented.
+While testing LLVM-libc with the CORE-MATH project's test suite, the `bfloat16` (also emulated) functions consistently failed.
+So we tested our `float128` functions with CORE-MATH and modified them to use the emulation internally for calculations, and the native `float128` when available for input/output, so that in the end the registers used for parameters/returns remain the same and the ABI mismatch is prevented.
 
 The work below on modifying the `float128` functions already uses this idea, making the `float128` functions ABI compatible.
 
@@ -69,29 +100,29 @@ The work below on modifying the `float128` functions already uses this idea, mak
 - Existing `float128` math functions were migrated to use the emulated type, one function (or function family) at a time, tracked under [#216576](https://github.com/llvm/llvm-project/issues/216576) (see table below).
 
 
-| Function / Family                                                                                     | PR                                                             |
-|--------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
-| `ceilf128`                                                                                              | [#207735](https://github.com/llvm/llvm-project/pull/207735)     |
-| `floorf128`                                                                                             | [#216552](https://github.com/llvm/llvm-project/pull/216552)     |
-| `truncf128`                                                                                             | [#216560](https://github.com/llvm/llvm-project/pull/216560)     |
-| `roundf128`                                                                                             | [#216563](https://github.com/llvm/llvm-project/pull/216563)     |
-| `roundevenf128`                                                                                          | [#216568](https://github.com/llvm/llvm-project/pull/216568)     |
-| `nearbyintf128`                                                                                          | [#217025](https://github.com/llvm/llvm-project/pull/217025)     |
-| `lrintf128`, `llrintf128`, `rintf128`                                                                   | [#217070](https://github.com/llvm/llvm-project/pull/217070)     |
-| `lroundf128`, `llroundf128`                                                                             | [#216829](https://github.com/llvm/llvm-project/pull/216829)     |
-| `fromfpf128`, `fromfpxf128`, `ufromfpf128`, `ufromfpxf128`                                              | [#216578](https://github.com/llvm/llvm-project/pull/216578)     |
-| `fabsf128`, `copysignf128`                                                                              | [#217389](https://github.com/llvm/llvm-project/pull/217389)     |
-| `fmaxf128`, `fminf128`                                                                                   | [#216575](https://github.com/llvm/llvm-project/pull/216575)     |
-| `fmaximumf128`, `fminimumf128`                                                                           | [#217390](https://github.com/llvm/llvm-project/pull/217390)     |
-| `fmaximum_numf128`, `fminimum_numf128`                                                                   | [#217409](https://github.com/llvm/llvm-project/pull/217409)     |
-| `fmaximum_magf128`, `fminimum_magf128`                                                                   | [#217539](https://github.com/llvm/llvm-project/pull/217539)     |
-| `fmaximum_mag_numf128`, `fminimum_mag_numf128`                                                           | [#217549](https://github.com/llvm/llvm-project/pull/217549)     |
-| `fdimf128`                                                                                               | [#217567](https://github.com/llvm/llvm-project/pull/217567)     |
-| `iscanonicalf128`, `isnanf128`, `issignalingf128`                                                       | [#217134](https://github.com/llvm/llvm-project/pull/217134)     |
-| `nextafterf128`, `nextupf128`, `nextdownf128`                                                           | [#217575](https://github.com/llvm/llvm-project/pull/217575)     |
-| `fmodf128`, `remainderf128`                                                                              | [#217578](https://github.com/llvm/llvm-project/pull/217578)     |
-| `sqrtf128`                                                                                               | [#216500](https://github.com/llvm/llvm-project/pull/216500)     |
-| `atan2f128`                                                                                              | [#216508](https://github.com/llvm/llvm-project/pull/216508)     |
+| Function / Family                                          | PR                                                          |
+|------------------------------------------------------------|-------------------------------------------------------------|
+| `ceilf128`                                                 | [#207735](https://github.com/llvm/llvm-project/pull/207735) |
+| `floorf128`                                                | [#216552](https://github.com/llvm/llvm-project/pull/216552) |
+| `truncf128`                                                | [#216560](https://github.com/llvm/llvm-project/pull/216560) |
+| `roundf128`                                                | [#216563](https://github.com/llvm/llvm-project/pull/216563) |
+| `roundevenf128`                                            | [#216568](https://github.com/llvm/llvm-project/pull/216568) |
+| `nearbyintf128`                                            | [#217025](https://github.com/llvm/llvm-project/pull/217025) |
+| `lrintf128`, `llrintf128`, `rintf128`                      | [#217070](https://github.com/llvm/llvm-project/pull/217070) |
+| `lroundf128`, `llroundf128`                                | [#216829](https://github.com/llvm/llvm-project/pull/216829) |
+| `fromfpf128`, `fromfpxf128`, `ufromfpf128`, `ufromfpxf128` | [#216578](https://github.com/llvm/llvm-project/pull/216578) |
+| `fabsf128`, `copysignf128`                                 | [#217389](https://github.com/llvm/llvm-project/pull/217389) |
+| `fmaxf128`, `fminf128`                                     | [#216575](https://github.com/llvm/llvm-project/pull/216575) |
+| `fmaximumf128`, `fminimumf128`                             | [#217390](https://github.com/llvm/llvm-project/pull/217390) |
+| `fmaximum_numf128`, `fminimum_numf128`                     | [#217409](https://github.com/llvm/llvm-project/pull/217409) |
+| `fmaximum_magf128`, `fminimum_magf128`                     | [#217539](https://github.com/llvm/llvm-project/pull/217539) |
+| `fmaximum_mag_numf128`, `fminimum_mag_numf128`             | [#217549](https://github.com/llvm/llvm-project/pull/217549) |
+| `fdimf128`                                                 | [#217567](https://github.com/llvm/llvm-project/pull/217567) |
+| `iscanonicalf128`, `isnanf128`, `issignalingf128`          | [#217134](https://github.com/llvm/llvm-project/pull/217134) |
+| `nextafterf128`, `nextupf128`, `nextdownf128`              | [#217575](https://github.com/llvm/llvm-project/pull/217575) |
+| `fmodf128`, `remainderf128`                                | [#217578](https://github.com/llvm/llvm-project/pull/217578) |
+| `sqrtf128`                                                 | [#216500](https://github.com/llvm/llvm-project/pull/216500) |
+| `atan2f128`                                                | [#216508](https://github.com/llvm/llvm-project/pull/216508) |
 
 ## Conclusion
 

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -28,7 +28,7 @@ The exact goals of this project were to:
 1. Add software emulation classes for the `float80` and `float128` formats.
 2. Provide the operator overloads and conversions needed for these classes to be used in place of the native types.
 3. Integrate the emulated types into the existing floating-point support infrastructure.
-4. Migrate the existing `float128` math functions to work correctly with the emulated type.
+4. Modify the existing `float128` math functions to work correctly with the emulated type.
 
 ## Interesting Challenges
 

--- a/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
+++ b/content/posts/2026-08-22-gsoc-float80-and-float128-in-llvm-libc.md
@@ -148,6 +148,6 @@ One of the most important things I learned was more about floating-point formats
 
 ## Acknowledgements
 
-I’m grateful to Google Summer of Code and the LLVM organization for giving me this opportunity. I would like to sincerely thank my mentors, Tue Ly, Nicolas Celik, and Krishna Pandey, for their guidance, support, and valuable feedback throughout this project and making this a great learning experience.
+I would like to sincerely thank my mentors, Tue Ly, Nicolas Celik, and Krishna Pandey, for their guidance, support, and valuable feedback throughout this project and making this a great learning experience. I’m grateful to Google Summer of Code admins and the LLVM organization for giving me this opportunity.
 
 I look forward to continuing my contributions to LLVM and the open-source community.


### PR DESCRIPTION
This is about my GSoC blog post for the project introducing emulated float80 and float128 types in llvm libc
Project link:
https://summerofcode.withgoogle.com/programs/2026/projects/r3Y64A3Y
Mentors: @krishna2803 @overmighty @lntue  

cc: @asl 